### PR TITLE
Scope Cloudflare deployment secrets to deployment steps

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -17,8 +17,6 @@ jobs:
     permissions:
       contents: read
     env:
-      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       EDGECHAT_ADMIN_USERNAME: ${{ secrets.EDGECHAT_ADMIN_USERNAME || secrets.CFCHAT_ADMIN_USERNAME }}
       EDGECHAT_ADMIN_PASSWORD: ${{ secrets.EDGECHAT_ADMIN_PASSWORD || secrets.CFCHAT_ADMIN_PASSWORD }}
       EDGECHAT_ADMIN_DISPLAY_NAME: ${{ secrets.EDGECHAT_ADMIN_DISPLAY_NAME || secrets.CFCHAT_ADMIN_DISPLAY_NAME }}
@@ -40,6 +38,9 @@ jobs:
 
       - name: Ensure Cloudflare resources
         id: ensure_resources
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: node .github/scripts/ensure-cloudflare-resources.mjs
 
       - name: Generate wrangler config for CI
@@ -51,6 +52,9 @@ jobs:
 
       - name: Initialize D1 schema (first creation only)
         if: steps.ensure_resources.outputs.d1_created == 'true'
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: npx wrangler d1 execute ${{ steps.ensure_resources.outputs.d1_database_name }} --remote --file worker/schema.sql --config wrangler.ci.toml
 
       - name: Generate admin bootstrap SQL (optional)
@@ -59,7 +63,13 @@ jobs:
 
       - name: Ensure admin user (optional)
         if: env.EDGECHAT_ADMIN_USERNAME != '' && env.EDGECHAT_ADMIN_PASSWORD != ''
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: npx wrangler d1 execute ${{ steps.ensure_resources.outputs.d1_database_name }} --remote --file .tmp/edgechat-admin-upsert.sql --config wrangler.ci.toml
 
       - name: Deploy worker
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: npx wrangler deploy --config wrangler.ci.toml


### PR DESCRIPTION
### Motivation

- Prevent CI secret exposure by removing `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` from the job-level environment so early steps do not inherit production credentials. 
- Reduce attack surface where dependency lifecycle scripts or malicious build steps could read and exfiltrate production Cloudflare credentials. 
- Keep the workflow able to provision and deploy Cloudflare resources while limiting credentials to only steps that actually call the Cloudflare API or `wrangler`.

### Description

- Removed `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` from the job-level `env` in `/.github/workflows/deploy-worker.yml` so checkout, `npm ci`, and frontend build run without those secrets. 
- Added step-level `env` entries for `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` on the specific steps that need them: the `Ensure Cloudflare resources` step (id `ensure_resources`), the conditional `Initialize D1 schema` step, the optional `Ensure admin user` step, and the `Deploy worker` step. 
- Left admin-related job-level secrets (`EDGECHAT_ADMIN_*`) in place so optional admin bootstrap behavior is unchanged. 

### Testing

- Ran `git diff --check`, which reported no whitespace or diff issues and passed. 
- Ran `npm run build`, which completed successfully and produced the frontend `dist` artifacts. 
- Ran `npm run biome:ci`, which failed due to pre-existing linting errors unrelated to this workflow change (these are existing code-style issues in the repository and not caused by the workflow modification).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4cdc6ad9f083288d4ee66c17d57d3b)