### PR TITLE
Revalidate WebSocket authorization for active connections

### DIFF
--- a/WEBSOCKET_AUTH.md
+++ b/WEBSOCKET_AUTH.md
@@ -25,14 +25,17 @@ headers.
 
 ## Connection lifetime semantics
 
-After the socket is established, the Durable Object does not revalidate session
-state or room membership on every message or broadcast.
+After the socket is established, the Durable Object revalidates the session and
+room membership before accepting each incoming message and before delivering each
+broadcast to a connected socket.
 
-That means these changes now take effect when the client reconnects:
+That means these changes take effect for active sockets as soon as the next
+message is sent to or from the room:
 
 - password reset
 - session invalidation
 - account disable or delete
 - removal from a private room
 
-Open sockets are no longer kicked immediately when those changes happen.
+Sockets that no longer pass session or room checks are closed with a policy
+violation status and are removed from the room connection set.

--- a/worker/src/do/ChannelRoom.js
+++ b/worker/src/do/ChannelRoom.js
@@ -8,8 +8,9 @@ const VERIFIED_IS_ADMIN_HEADER = 'x-cfchat-verified-is-admin';
 const VERIFIED_AT_HEADER = 'x-cfchat-verified-at';
 const MESSAGE_SIZE_LIMIT = 10 * 1024;
 
-function socketMeta(principal, room) {
+function socketMeta(token, principal, room) {
   return {
+    token,
     principal,
     room
   };
@@ -91,8 +92,58 @@ export class ChannelRoom {
     }
   }
 
-  broadcast(packet) {
-    for (const socket of this.connections.keys()) {
+  async revalidateConnection(ws, meta) {
+    if (!meta?.token) {
+      return null;
+    }
+
+    const auth = await validateSession(this.env, meta.token);
+    if (!auth.ok) {
+      this.closeUnauthorizedSocket(ws);
+      return null;
+    }
+
+    const room = await requireAccessibleRoom(
+      this.env.DB,
+      auth.session.userId,
+      meta.room.kind,
+      meta.room.id,
+      auth.session.isAdmin
+    );
+    if (!room) {
+      this.closeUnauthorizedSocket(ws);
+      return null;
+    }
+
+    const nextMeta = socketMeta(
+      meta.token,
+      {
+        userId: auth.session.userId,
+        isAdmin: auth.session.isAdmin
+      },
+      room
+    );
+    this.connections.set(ws, nextMeta);
+    ws.serializeAttachment(nextMeta);
+    return nextMeta;
+  }
+
+  closeUnauthorizedSocket(ws) {
+    this.connections.delete(ws);
+    try {
+      ws.close(1008, 'Unauthorized');
+    } catch {
+      // Ignore broken sockets.
+    }
+  }
+
+  async broadcast(packet) {
+    for (const [socket, meta] of this.connections) {
+      const currentMeta = await this.revalidateConnection(socket, meta);
+      if (!currentMeta) {
+        continue;
+      }
+
       try {
         socket.send(packet);
       } catch {
@@ -140,7 +191,7 @@ export class ChannelRoom {
     const pair = new WebSocketPair();
     const [client, server] = Object.values(pair);
     this.state.acceptWebSocket(server);
-    const meta = socketMeta(principal, room);
+    const meta = socketMeta(token, principal, room);
     server.serializeAttachment(meta);
     this.connections.set(server, meta);
     server.send(
@@ -179,9 +230,14 @@ export class ChannelRoom {
     }
 
     try {
+      const currentMeta = await this.revalidateConnection(ws, meta);
+      if (!currentMeta) {
+        return;
+      }
+
       const saved = await insertMessage(this.env.DB, {
-        channelId: meta.room.id,
-        senderId: meta.principal.userId,
+        channelId: currentMeta.room.id,
+        senderId: currentMeta.principal.userId,
         content: payload.content,
         attachment: pickAttachment(payload.attachment)
       });
@@ -190,8 +246,8 @@ export class ChannelRoom {
         message: saved
       });
 
-      this.broadcast(packet);
-      await this.notifyUnreadRecipients(meta, saved);
+      await this.broadcast(packet);
+      await this.notifyUnreadRecipients(currentMeta, saved);
     } catch (error) {
       sendSocketError(ws, error.message || 'Send failed');
     }


### PR DESCRIPTION
### Motivation

- A previous change validated session and room membership only during the WebSocket handshake, which allowed revoked users or invalidated sessions to continue reading and writing on already-open sockets until reconnect. 

### Description

- Store the session token in each connection's socket metadata so the Durable Object can revalidate the session later via `validateSession`.
- Add `revalidateConnection(ws, meta)` to re-run `validateSession` and `requireAccessibleRoom`, update socket metadata, and close sockets that fail checks.
- Revalidate each socket before delivering a `broadcast` and revalidate the sender before accepting an incoming `send` message, using the refreshed metadata for inserts and notifications.
- Update `WEBSOCKET_AUTH.md` to document that session and membership changes take effect for active sockets immediately (they are closed on next message/broadcast if checks fail).

### Testing

- Ran `node --check worker/src/do/ChannelRoom.js`, which completed successfully.
- Ran `npx biome check worker/src/do/ChannelRoom.js WEBSOCKET_AUTH.md`, which succeeded for the targeted files.
- Built the frontend with `npm run build`, which completed successfully.
- Running the repository-wide lint via the project's `biome:check` script failed due to pre-existing diagnostics elsewhere in the repo and not due to the changes in these files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4cdb8530bc8328b1d792bdcb319dae)