### PR TITLE
Scope admin bootstrap secrets to SQL generation step

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -19,9 +19,6 @@ jobs:
     env:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-      EDGECHAT_ADMIN_USERNAME: ${{ secrets.EDGECHAT_ADMIN_USERNAME || secrets.CFCHAT_ADMIN_USERNAME }}
-      EDGECHAT_ADMIN_PASSWORD: ${{ secrets.EDGECHAT_ADMIN_PASSWORD || secrets.CFCHAT_ADMIN_PASSWORD }}
-      EDGECHAT_ADMIN_DISPLAY_NAME: ${{ secrets.EDGECHAT_ADMIN_DISPLAY_NAME || secrets.CFCHAT_ADMIN_DISPLAY_NAME }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -54,11 +51,20 @@ jobs:
         run: npx wrangler d1 execute ${{ steps.ensure_resources.outputs.d1_database_name }} --remote --file worker/schema.sql --config wrangler.ci.toml
 
       - name: Generate admin bootstrap SQL (optional)
-        if: env.EDGECHAT_ADMIN_USERNAME != '' && env.EDGECHAT_ADMIN_PASSWORD != ''
-        run: node .github/scripts/generate-admin-bootstrap-sql.mjs
+        env:
+          EDGECHAT_ADMIN_USERNAME: ${{ secrets.EDGECHAT_ADMIN_USERNAME || secrets.CFCHAT_ADMIN_USERNAME }}
+          EDGECHAT_ADMIN_PASSWORD: ${{ secrets.EDGECHAT_ADMIN_PASSWORD || secrets.CFCHAT_ADMIN_PASSWORD }}
+          EDGECHAT_ADMIN_DISPLAY_NAME: ${{ secrets.EDGECHAT_ADMIN_DISPLAY_NAME || secrets.CFCHAT_ADMIN_DISPLAY_NAME }}
+        shell: bash
+        run: |
+          if [[ -n "$EDGECHAT_ADMIN_USERNAME" && -n "$EDGECHAT_ADMIN_PASSWORD" ]]; then
+            node .github/scripts/generate-admin-bootstrap-sql.mjs
+          else
+            echo "Skipping admin bootstrap SQL generation; admin credentials were not provided."
+          fi
 
       - name: Ensure admin user (optional)
-        if: env.EDGECHAT_ADMIN_USERNAME != '' && env.EDGECHAT_ADMIN_PASSWORD != ''
+        if: hashFiles('.tmp/edgechat-admin-upsert.sql') != ''
         run: npx wrangler d1 execute ${{ steps.ensure_resources.outputs.d1_database_name }} --remote --file .tmp/edgechat-admin-upsert.sql --config wrangler.ci.toml
 
       - name: Deploy worker


### PR DESCRIPTION
### Motivation
- The deploy job exposed admin bootstrap credentials (`CFCHAT_ADMIN_*` / `EDGECHAT_ADMIN_*`) as job-level `env`, which made the admin password available to all steps in the job and increased risk of secret exfiltration. 
- The admin password is only required by the admin SQL generation step and should not be inherited by earlier steps like dependency install, build, or third-party actions.

### Description
- Removed `EDGECHAT_ADMIN_USERNAME`, `EDGECHAT_ADMIN_PASSWORD`, and `EDGECHAT_ADMIN_DISPLAY_NAME` from the job-level `env` in `.github/workflows/deploy-worker.yml`. 
- Scoped the admin credentials to the `Generate admin bootstrap SQL (optional)` step by adding a step-local `env` block that sources the secrets and running the script under a `shell: bash` conditional that only executes when both values are present. 
- Changed the `Ensure admin user (optional)` step to run only when the generated SQL exists by using `if: hashFiles('.tmp/edgechat-admin-upsert.sql') != ''` so the upsert runs only after SQL generation. 
- Preserved existing behavior by skipping SQL generation when credentials are not provided and still performing the D1 upsert when the SQL file is present.

### Testing
- Ran a Python assertion that verifies `EDGECHAT_ADMIN_PASSWORD` is not present in the job-level `env` and is present only in the `Generate admin bootstrap SQL` step, and it passed. 
- Parsed the workflow YAML with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy-worker.yml")'` to confirm valid syntax, and it passed. 
- Executed `git diff --check` to validate whitespace/patch issues, and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4cdcb3ad1c8328a5d5407376e868eb)