### PR TITLE
Fix admin privilege source (remove ADMIN_USERNAMES-based grants)

### DIFF
--- a/worker/src/auth.js
+++ b/worker/src/auth.js
@@ -50,18 +50,8 @@ function toSessionVersion(value) {
   return Number.isFinite(numeric) ? numeric : 0;
 }
 
-function parseAdminUsernames(env) {
-  return String(env.ADMIN_USERNAMES || '')
-    .split(',')
-    .map((username) => username.trim().toLowerCase())
-    .filter(Boolean);
-}
-
-export function isAdminUser(env, user) {
-  const username = String(user?.username || '')
-    .trim()
-    .toLowerCase();
-  return Boolean(Number(user?.is_admin)) || parseAdminUsernames(env).includes(username);
+export function isAdminUser(_env, user) {
+  return Boolean(Number(user?.is_admin));
 }
 
 export async function putSession(env, session) {

--- a/wrangler.example.toml
+++ b/wrangler.example.toml
@@ -5,7 +5,6 @@ compatibility_date = "2026-04-05"
 compatibility_flags = ["nodejs_compat"]
 
 [vars]
-ADMIN_USERNAMES = "admin"
 MESSAGE_RETENTION_DAYS = "7"
 SOFT_DELETE_RETENTION_DAYS = "60"
 GC_BATCH_SIZE = "500"


### PR DESCRIPTION
### Motivation
- Prevent privilege escalation where case-variant usernames could match the `ADMIN_USERNAMES` environment variable and obtain administrator access despite the database `users.is_admin` flag being false.

### Description
- Remove `parseAdminUsernames` and make `isAdminUser` depend only on the persisted `user.is_admin` flag, and remove the `ADMIN_USERNAMES` example variable from `wrangler.example.toml` so username-based admin grants are no longer suggested.

### Testing
- Ran an automated Node check that exercises `isAdminUser` (ensuring `Admin` with `is_admin: 0` is not granted admin and `is_admin: 1` still grants admin), ran `npx biome ci worker/src/auth.js wrangler.example.toml` and `npm run build` which succeeded, and verified the full `npm run biome:ci && npm run build` previously failed due to unrelated repository lint errors outside the changed files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4cdd4e6b248328b190b283cc0183a2)