### PR TITLE
Reject invite registrations that match configured admin usernames

### DIFF
--- a/worker/src/auth.js
+++ b/worker/src/auth.js
@@ -57,11 +57,13 @@ function parseAdminUsernames(env) {
     .filter(Boolean);
 }
 
+export function isConfiguredAdminUsername(env, username) {
+  const normalizedUsername = String(username || '').trim().toLowerCase();
+  return Boolean(normalizedUsername) && parseAdminUsernames(env).includes(normalizedUsername);
+}
+
 export function isAdminUser(env, user) {
-  const username = String(user?.username || '')
-    .trim()
-    .toLowerCase();
-  return Boolean(Number(user?.is_admin)) || parseAdminUsernames(env).includes(username);
+  return Boolean(Number(user?.is_admin)) || isConfiguredAdminUsername(env, user?.username);
 }
 
 export async function putSession(env, session) {

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -5,6 +5,7 @@ import {
   deleteSession,
   getSession,
   hashPassword,
+  isConfiguredAdminUsername,
   putSession,
   verifyPassword
 } from './auth.js';
@@ -97,6 +98,9 @@ app.post('/api/register-links/:token/register', async (c) => {
   }
   if (!username || !password) {
     return errorResponse('用户名和密码不能为空');
+  }
+  if (isConfiguredAdminUsername(c.env, username)) {
+    return errorResponse('该用户名不可用于邀请注册');
   }
 
   const inviteQuery = await c.env.DB.prepare(


### PR DESCRIPTION
### Motivation
- A public invite registration endpoint allowed creating usernames that normalized to configured administrator names (e.g. registering `Admin` when `ADMIN_USERNAMES=admin`), enabling privilege escalation because admin status is computed from a lowercased username.

### Description
- Add `isConfiguredAdminUsername(env, username)` in `worker/src/auth.js` to normalize and check configured admin names via `ADMIN_USERNAMES`.
- Update `isAdminUser` in `worker/src/auth.js` to reuse the new helper so admin checks remain consistent.
- Import the helper in `worker/src/index.js` and block invite-based registration in the `POST /api/register-links/:token/register` route by returning an error when `isConfiguredAdminUsername(c.env, username)` is true.
- Changes touch `worker/src/auth.js` and `worker/src/index.js` and preserve existing session/admin behavior while preventing invite holders from registering case-variants of configured admin usernames.

### Testing
- Ran `npx biome check worker/src/auth.js worker/src/index.js` with no errors for the modified files. (Passed)
- Executed a local invocation with `node --input-type=module` to call the register endpoint and confirmed a request creating username `Admin` is rejected when `ADMIN_USERNAMES=admin`. (Verified)
- Ran `npm run build` to ensure bundling succeeds for the worker/frontend build steps. (Passed)
- Ran the full repository check `npm run biome:check`, which reported unrelated pre-existing frontend lint/parse diagnostics; those failures are not related to the backend fix. (Unrelated failures)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4ce010f194832896062c47d8bbe01f)