### PR TITLE
feat(admin): add on-demand R2 storage statistics

### DIFF
--- a/frontend/src/admin/navigation.js
+++ b/frontend/src/admin/navigation.js
@@ -1,4 +1,4 @@
-import { Gauge, Send, Settings, UserCog, UserPlus } from '@lucide/vue';
+import { Database, Gauge, Send, Settings, UserCog, UserPlus } from '@lucide/vue';
 
 export const adminNavigation = [
   {
@@ -14,6 +14,13 @@ export const adminNavigation = [
     description: '维护现有账号与权限',
     to: '/admin/users',
     icon: UserCog
+  },
+  {
+    id: 'storage',
+    label: '存储统计',
+    description: '查看每个用户的 R2 存储占用',
+    to: '/admin/storage',
+    icon: Database
   },
   {
     id: 'invites',
@@ -49,6 +56,7 @@ export const adminNavigation = [
 export const adminRouteIcons = {
   dashboard: Gauge,
   users: UserCog,
+  storage: Database,
   invites: UserPlus,
   telegram: Send,
   site: Settings

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -192,6 +192,14 @@ export default {
   adminOverview() {
     return request('/admin/overview');
   },
+  adminStorageScan(cursor = '') {
+    const query = new URLSearchParams();
+    if (cursor) {
+      query.set('cursor', cursor);
+    }
+    const suffix = query.size ? `?${query.toString()}` : '';
+    return request(`/admin/storage/scan${suffix}`);
+  },
   adminSiteSettings() {
     return request('/admin/site-settings');
   },

--- a/frontend/src/pages/AdminStoragePage.vue
+++ b/frontend/src/pages/AdminStoragePage.vue
@@ -1,0 +1,171 @@
+<script setup>
+import { ArrowDown, ArrowUp, ChevronsUpDown, RefreshCw } from '@lucide/vue';
+import { computed, ref } from 'vue';
+import api from '../api.js';
+import UiButton from '../components/ui/Button.vue';
+import UiSurface from '../components/ui/Surface.vue';
+import {
+  buildStorageRows,
+  formatByteSize,
+  formatStorageDateTime,
+  mergeStorageSummary,
+  sortStorageRows
+} from '../storage-statistics.js';
+
+const loading = ref(false);
+const error = ref('');
+const hasResult = ref(false);
+const users = ref([]);
+const summaries = ref(new Map());
+const refreshedAt = ref(null);
+const sort = ref({ key: 'bytes', direction: 'desc' });
+
+const rows = computed(() => buildStorageRows(users.value, summaries.value));
+const sortedRows = computed(() => sortStorageRows(rows.value, sort.value));
+const totalBytes = computed(() => rows.value.reduce((total, row) => total + row.bytes, 0));
+const totalObjects = computed(() => rows.value.reduce((total, row) => total + row.objectCount, 0));
+const occupiedUsers = computed(
+  () => rows.value.filter((row) => row.ownerKey.startsWith('user:') && row.bytes > 0).length
+);
+
+const columns = [
+  { key: 'objectCount', label: '文件数量' },
+  { key: 'bytes', label: '实际占用' },
+  { key: 'share', label: '占总量比例' },
+  { key: 'latestUploadedAt', label: '最近上传' }
+];
+
+async function refreshStorage() {
+  loading.value = true;
+  error.value = '';
+  const nextSummaries = new Map();
+  const seenCursors = new Set();
+  let cursor = '';
+  let nextUsers = [];
+
+  try {
+    do {
+      const payload = await api.adminStorageScan(cursor);
+      if (!cursor) {
+        nextUsers = payload.users || [];
+      }
+      mergeStorageSummary(nextSummaries, payload.items);
+
+      if (!payload.truncated) {
+        cursor = '';
+        break;
+      }
+      if (!payload.cursor || seenCursors.has(payload.cursor)) {
+        throw new Error('R2 分页游标异常，请重试');
+      }
+      seenCursors.add(payload.cursor);
+      cursor = payload.cursor;
+    } while (cursor);
+
+    users.value = nextUsers;
+    summaries.value = nextSummaries;
+    refreshedAt.value = new Date();
+    hasResult.value = true;
+  } catch (currentError) {
+    error.value = currentError.message;
+  } finally {
+    loading.value = false;
+  }
+}
+
+function changeSort(key) {
+  sort.value = {
+    key,
+    direction: sort.value.key === key && sort.value.direction === 'desc' ? 'asc' : 'desc'
+  };
+}
+
+function sortIcon(key) {
+  if (sort.value.key !== key) return ChevronsUpDown;
+  return sort.value.direction === 'asc' ? ArrowUp : ArrowDown;
+}
+
+function ariaSort(key) {
+  if (sort.value.key !== key) return 'none';
+  return sort.value.direction === 'asc' ? 'ascending' : 'descending';
+}
+
+function formatShare(value) {
+  return `${(Number(value || 0) * 100).toFixed(value > 0 && value < 0.001 ? 2 : 1)}%`;
+}
+</script>
+
+<template>
+  <div class="admin-section admin-storage-page">
+    <header class="admin-section__header">
+      <div class="admin-section__heading">
+        <h2>存储统计</h2>
+        <p>按用户统计 R2 中当前实际存在的文件与占用空间。</p>
+      </div>
+      <UiButton variant="secondary" :disabled="loading" @click="refreshStorage">
+        <RefreshCw :size="17" aria-hidden="true" :class="{ 'admin-spin': loading }" />
+        {{ loading ? '刷新中...' : '刷新' }}
+      </UiButton>
+    </header>
+
+    <div class="admin-section__body">
+      <p v-if="error" class="error-text">{{ error }}</p>
+
+      <template v-if="hasResult">
+        <section class="admin-metric-grid" aria-label="R2 存储汇总">
+          <UiSurface class="admin-metric-card">
+            <span>当前总占用</span>
+            <strong>{{ formatByteSize(totalBytes) }}</strong>
+          </UiSurface>
+          <UiSurface class="admin-metric-card">
+            <span>文件总数</span>
+            <strong>{{ totalObjects }}</strong>
+          </UiSurface>
+          <UiSurface class="admin-metric-card">
+            <span>有占用用户</span>
+            <strong>{{ occupiedUsers }}</strong>
+          </UiSurface>
+          <UiSurface class="admin-metric-card">
+            <span>最后刷新</span>
+            <strong class="admin-storage-page__refresh-time">
+              {{ formatStorageDateTime(refreshedAt) }}
+            </strong>
+          </UiSurface>
+        </section>
+
+        <UiSurface class="panel panel--table">
+          <h3 class="panel-title">用户存储情况</h3>
+          <div class="admin-table-wrap">
+            <table class="list-table admin-storage-table">
+              <thead>
+                <tr>
+                  <th>用户</th>
+                  <th v-for="column in columns" :key="column.key" :aria-sort="ariaSort(column.key)">
+                    <button type="button" class="admin-sort-button" @click="changeSort(column.key)">
+                      {{ column.label }}
+                      <component :is="sortIcon(column.key)" :size="15" aria-hidden="true" />
+                    </button>
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-for="row in sortedRows" :key="row.ownerKey">
+                  <td>
+                    <strong>{{ row.displayName }}</strong>
+                    <div v-if="row.username" class="muted">
+                      @{{ row.username }}<span v-if="row.isDeleted"> · 已删除</span>
+                    </div>
+                  </td>
+                  <td>{{ row.objectCount }}</td>
+                  <td>{{ formatByteSize(row.bytes) }}</td>
+                  <td>{{ formatShare(row.share) }}</td>
+                  <td>{{ formatStorageDateTime(row.latestUploadedAt) || '-' }}</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </UiSurface>
+      </template>
+    </div>
+  </div>
+</template>

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -6,6 +6,7 @@ import ChatPage from './pages/ChatPage.vue';
 import AdminPage from './pages/AdminPage.vue';
 import AdminDashboardPage from './pages/AdminDashboardPage.vue';
 import AdminUsersPage from './pages/AdminUsersPage.vue';
+import AdminStoragePage from './pages/AdminStoragePage.vue';
 import AdminInvitesPage from './pages/AdminInvitesPage.vue';
 import AdminSitePage from './pages/AdminSitePage.vue';
 import AdminTelegramPage from './pages/AdminTelegramPage.vue';
@@ -53,6 +54,12 @@ const router = createRouter({
           name: 'admin-users',
           component: AdminUsersPage,
           meta: { admin: true, adminTitle: '用户管理', adminIcon: 'users', transition: 'page' }
+        },
+        {
+          path: 'storage',
+          name: 'admin-storage',
+          component: AdminStoragePage,
+          meta: { admin: true, adminTitle: '存储统计', adminIcon: 'storage', transition: 'page' }
         },
         {
           path: 'invites',

--- a/frontend/src/storage-statistics.js
+++ b/frontend/src/storage-statistics.js
@@ -1,0 +1,126 @@
+export function storageTimestampValue(value) {
+  if (value === null || value === undefined || value === '') return 0;
+  const timestamp = new Date(value).getTime();
+  return Number.isNaN(timestamp) ? 0 : timestamp;
+}
+
+export function formatStorageDateTime(value) {
+  const timestamp = storageTimestampValue(value);
+  return timestamp ? new Date(timestamp).toLocaleString() : '';
+}
+
+export function formatByteSize(value) {
+  const bytes = Math.max(0, Number(value) || 0);
+  if (bytes < 1024) return `${bytes} B`;
+
+  const units = ['KiB', 'MiB', 'GiB', 'TiB'];
+  let size = bytes / 1024;
+  let unitIndex = 0;
+  while (size >= 1024 && unitIndex < units.length - 1) {
+    size /= 1024;
+    unitIndex += 1;
+  }
+  const fractionDigits = size >= 100 ? 0 : size >= 10 ? 1 : 2;
+  return `${size.toFixed(fractionDigits)} ${units[unitIndex]}`;
+}
+
+export function mergeStorageSummary(target, items = []) {
+  for (const item of items) {
+    const current = target.get(item.ownerKey) || {
+      ownerKey: item.ownerKey,
+      ownerType: item.ownerType,
+      ownerId: item.ownerId,
+      objectCount: 0,
+      bytes: 0,
+      latestUploadedAt: null
+    };
+    current.objectCount += Number(item.objectCount) || 0;
+    current.bytes += Number(item.bytes) || 0;
+    if (
+      storageTimestampValue(item.latestUploadedAt) >
+      storageTimestampValue(current.latestUploadedAt)
+    ) {
+      current.latestUploadedAt = item.latestUploadedAt;
+    }
+    target.set(item.ownerKey, current);
+  }
+  return target;
+}
+
+export function buildStorageRows(users = [], summaries = new Map()) {
+  const usersById = new Map(users.map((user) => [Number(user.id), user]));
+  const rows = users
+    .filter((user) => !user.isDeleted)
+    .map((user) => storageUserRow(user, summaries.get(`user:${Number(user.id)}`)));
+
+  for (const summary of summaries.values()) {
+    if (summary.ownerType === 'user') {
+      const user = usersById.get(Number(summary.ownerId));
+      if (user?.isDeleted) {
+        rows.push(storageUserRow(user, summary));
+      } else if (!user) {
+        rows.push({
+          ...storageValues(summary),
+          ownerKey: summary.ownerKey,
+          displayName: `未知用户 #${summary.ownerId}`,
+          username: '',
+          isDeleted: true
+        });
+      }
+      continue;
+    }
+
+    rows.push({
+      ...storageValues(summary),
+      ownerKey: summary.ownerKey,
+      displayName: summary.ownerType === 'telegram' ? '系统 / Telegram' : '未知 / 历史文件',
+      username: '',
+      isDeleted: false
+    });
+  }
+
+  const totalBytes = rows.reduce((total, row) => total + row.bytes, 0);
+  return rows.map((row) => ({
+    ...row,
+    share: totalBytes > 0 ? row.bytes / totalBytes : 0
+  }));
+}
+
+function storageValues(summary) {
+  return {
+    objectCount: Number(summary?.objectCount) || 0,
+    bytes: Number(summary?.bytes) || 0,
+    latestUploadedAt: summary?.latestUploadedAt || null
+  };
+}
+
+function storageUserRow(user, summary) {
+  return {
+    ...storageValues(summary),
+    ownerKey: `user:${Number(user.id)}`,
+    displayName: user.displayName,
+    username: user.username,
+    isDeleted: Boolean(user.isDeleted)
+  };
+}
+
+export function sortStorageRows(rows, sort) {
+  const direction = sort.direction === 'asc' ? 1 : -1;
+  return [...rows].sort((left, right) => {
+    if (sort.key === 'latestUploadedAt') {
+      const leftTime = storageTimestampValue(left.latestUploadedAt);
+      const rightTime = storageTimestampValue(right.latestUploadedAt);
+      if (!leftTime && !rightTime) return compareNames(left, right);
+      if (!leftTime) return 1;
+      if (!rightTime) return -1;
+      return (leftTime - rightTime) * direction || compareNames(left, right);
+    }
+
+    const difference = (Number(left[sort.key]) || 0) - (Number(right[sort.key]) || 0);
+    return difference * direction || compareNames(left, right);
+  });
+}
+
+function compareNames(left, right) {
+  return String(left.displayName).localeCompare(String(right.displayName), 'zh-CN');
+}

--- a/frontend/src/styles/admin.css
+++ b/frontend/src/styles/admin.css
@@ -8,3 +8,4 @@
 @import './admin/content.css';
 @import './admin/controls.css';
 @import './admin/tables.css';
+@import './admin/storage.css';

--- a/frontend/src/styles/admin/storage.css
+++ b/frontend/src/styles/admin/storage.css
@@ -1,0 +1,36 @@
+.admin-page .admin-metric-card .admin-storage-page__refresh-time {
+  font-size: 0.95rem;
+  line-height: 1.25;
+}
+
+.admin-page .admin-storage-table {
+  min-width: 54rem;
+}
+
+.admin-storage-table td:not(:first-child) {
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.admin-sort-button {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--admin-space-3xs);
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+}
+
+.admin-sort-button:hover,
+.admin-sort-button:active {
+  color: var(--admin-text);
+}
+
+.admin-sort-button:focus-visible {
+  outline: 2px solid var(--admin-focus);
+  outline-offset: 3px;
+  border-radius: 2px;
+}

--- a/test/admin-ui.test.js
+++ b/test/admin-ui.test.js
@@ -14,6 +14,7 @@ const navigationSource = read('../frontend/src/admin/navigation.js');
 const sidebarSource = read('../frontend/src/components/admin/AdminSidebar.vue');
 const dashboardSource = read('../frontend/src/pages/AdminDashboardPage.vue');
 const usersSource = read('../frontend/src/pages/AdminUsersPage.vue');
+const storageSource = read('../frontend/src/pages/AdminStoragePage.vue');
 const invitesSource = read('../frontend/src/pages/AdminInvitesPage.vue');
 const userCreatorSource = read('../frontend/src/components/admin/AdminUserCreator.vue');
 const inviteManagerSource = read('../frontend/src/components/admin/RegistrationInviteManager.vue');
@@ -38,9 +39,9 @@ test('后台默认进入仪表盘并新增受保护的注册邀请页', () => {
   assert.match(routerSource, /meta: \{ admin: true/);
 });
 
-test('侧栏保留五个管理分类并移除消息查看入口', () => {
+test('侧栏包含存储统计并移除消息查看入口', () => {
   assert.match(sidebarSource, /Edgecht 管理后台/);
-  for (const id of ['dashboard', 'users', 'invites', 'telegram', 'site']) {
+  for (const id of ['dashboard', 'users', 'storage', 'invites', 'telegram', 'site']) {
     assert.match(navigationSource, new RegExp(`id: '${id}'`));
   }
   assert.match(navigationSource, /label: '创建用户'/);
@@ -51,6 +52,21 @@ test('侧栏保留五个管理分类并移除消息查看入口', () => {
   assert.match(sidebarSource, /v-if="!item\.children"/);
   assert.match(sidebarSource, /:aria-expanded="isGroupOpen\(item\)"/);
   assert.match(sidebarSource, /v-show="isGroupOpen\(item\)"/);
+});
+
+test('存储统计由按钮手动刷新且四个统计列均可排序', () => {
+  assert.match(routerSource, /import AdminStoragePage/);
+  assert.match(routerSource, /path: 'storage'/);
+  assert.match(apiSource, /adminStorageScan/);
+  assert.match(adminApiSource, /\/api\/admin\/storage\/scan/);
+  assert.match(adminApiSource, /FILES\.list/);
+  assert.match(storageSource, /@click="refreshStorage"/);
+  assert.doesNotMatch(storageSource, /onMounted\(refreshStorage\)/);
+  assert.doesNotMatch(storageSource, /尚未统计|10 GB|免费存储/);
+  for (const key of ['objectCount', 'bytes', 'share', 'latestUploadedAt']) {
+    assert.match(storageSource, new RegExp(`key: '${key}'`));
+  }
+  assert.match(storageSource, /@click="changeSort\(column\.key\)"/);
 });
 
 test('用户管理只维护用户列表，创建用户和注册链接集中在注册邀请页', () => {
@@ -142,6 +158,7 @@ test('后台核心 Vue 文件保持在单一职责的可维护规模', () => {
     ['AdminSidebar', sidebarSource],
     ['AdminDashboardPage', dashboardSource],
     ['AdminUsersPage', usersSource],
+    ['AdminStoragePage', storageSource],
     ['AdminTelegramPage', telegramSource],
     ['AdminSitePage', siteSource]
   ]) {

--- a/test/storage-statistics.test.js
+++ b/test/storage-statistics.test.js
@@ -1,0 +1,125 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  buildStorageRows,
+  formatByteSize,
+  mergeStorageSummary,
+  sortStorageRows
+} from '../frontend/src/storage-statistics.js';
+import {
+  storageOwnerFromObjectKey,
+  summarizeR2Objects
+} from '../worker/src/storage-statistics.js';
+
+test('R2 object keys resolve to users, Telegram, and unknown owners', () => {
+  assert.deepEqual(storageOwnerFromObjectKey('12/file.png'), {
+    key: 'user:12',
+    type: 'user',
+    userId: 12
+  });
+  assert.deepEqual(storageOwnerFromObjectKey('telegram/chat/file.bin'), {
+    key: 'system:telegram',
+    type: 'telegram',
+    userId: null
+  });
+  assert.deepEqual(storageOwnerFromObjectKey('legacy/file.bin'), {
+    key: 'system:unknown',
+    type: 'unknown',
+    userId: null
+  });
+});
+
+test('one R2 page is aggregated without exposing object keys', () => {
+  const items = summarizeR2Objects([
+    { key: '2/a.bin', size: 100, uploaded: new Date('2026-08-11T00:00:00Z') },
+    { key: '2/b.bin', size: 250, uploaded: new Date('2026-08-12T00:00:00Z') },
+    { key: 'telegram/1/c.bin', size: 50, uploaded: new Date('2026-08-10T00:00:00Z') }
+  ]);
+
+  assert.deepEqual(items, [
+    {
+      ownerKey: 'user:2',
+      ownerType: 'user',
+      ownerId: 2,
+      objectCount: 2,
+      bytes: 350,
+      latestUploadedAt: '2026-08-12T00:00:00.000Z'
+    },
+    {
+      ownerKey: 'system:telegram',
+      ownerType: 'telegram',
+      ownerId: null,
+      objectCount: 1,
+      bytes: 50,
+      latestUploadedAt: '2026-08-10T00:00:00.000Z'
+    }
+  ]);
+  assert.equal('key' in items[0], false);
+});
+
+test('paged summaries merge and include active zero-usage users', () => {
+  const summaries = new Map();
+  mergeStorageSummary(summaries, [
+    {
+      ownerKey: 'user:1',
+      ownerType: 'user',
+      ownerId: 1,
+      objectCount: 1,
+      bytes: 10,
+      latestUploadedAt: '2026-08-11T00:00:00Z'
+    }
+  ]);
+  mergeStorageSummary(summaries, [
+    {
+      ownerKey: 'user:1',
+      ownerType: 'user',
+      ownerId: 1,
+      objectCount: 2,
+      bytes: 20,
+      latestUploadedAt: '2026-08-12T00:00:00Z'
+    }
+  ]);
+
+  const rows = buildStorageRows(
+    [
+      { id: 1, username: 'one', displayName: 'One', isDeleted: false },
+      { id: 2, username: 'two', displayName: 'Two', isDeleted: false }
+    ],
+    summaries
+  );
+  assert.equal(rows.find((row) => row.ownerKey === 'user:1').bytes, 30);
+  assert.equal(rows.find((row) => row.ownerKey === 'user:1').objectCount, 3);
+  assert.equal(rows.find((row) => row.ownerKey === 'user:2').bytes, 0);
+  assert.equal(rows.find((row) => row.ownerKey === 'user:1').share, 1);
+});
+
+test('storage rows sort numerically and missing upload times stay last', () => {
+  const rows = [
+    { displayName: 'A', bytes: 2, objectCount: 2, share: 0.2, latestUploadedAt: null },
+    {
+      displayName: 'B',
+      bytes: 10,
+      objectCount: 1,
+      share: 0.8,
+      latestUploadedAt: '2026-08-12T00:00:00Z'
+    }
+  ];
+  assert.deepEqual(
+    sortStorageRows(rows, { key: 'bytes', direction: 'desc' }).map((row) => row.displayName),
+    ['B', 'A']
+  );
+  assert.deepEqual(
+    sortStorageRows(rows, { key: 'objectCount', direction: 'desc' }).map(
+      (row) => row.displayName
+    ),
+    ['A', 'B']
+  );
+  assert.deepEqual(
+    sortStorageRows(rows, { key: 'latestUploadedAt', direction: 'asc' }).map(
+      (row) => row.displayName
+    ),
+    ['B', 'A']
+  );
+  assert.equal(formatByteSize(10 * 1024 * 1024), '10.0 MiB');
+});

--- a/worker/src/api/admin.js
+++ b/worker/src/api/admin.js
@@ -9,11 +9,36 @@ import {
   revokeRegistrationInvite
 } from '../data/registration-invites.js';
 import { getSiteSettings, updateSiteSettings } from '../data/site-settings.js';
-import { listAdminUsers } from '../data/users.js';
+import { listAdminUsers, listStorageOwners } from '../data/users.js';
 import { ApiError } from '../errors.js';
+import { summarizeR2Objects } from '../storage-statistics.js';
 import { errorResponse, parseJsonRequest, randomToken } from '../utils.js';
 
+const STORAGE_SCAN_PAGE_SIZE = 1000;
+
 export function registerAdminRoutes(app) {
+  app.get('/api/admin/storage/scan', async (c) => {
+    const cursor = new URL(c.req.url).searchParams.get('cursor') || undefined;
+    const listed = await c.env.FILES.list({
+      limit: STORAGE_SCAN_PAGE_SIZE,
+      ...(cursor ? { cursor } : {}),
+      include: []
+    });
+    const response = {
+      items: summarizeR2Objects(listed.objects),
+      scannedObjects: listed.objects.length,
+      truncated: listed.truncated,
+      cursor: listed.truncated ? listed.cursor : null
+    };
+
+    if (!cursor) {
+      response.users = await listStorageOwners(c.env.DB);
+    }
+
+    c.header('Cache-Control', 'private, no-store');
+    return c.json(response);
+  });
+
   app.get('/api/admin/overview', async (c) => {
     const [users, channels, dms, site] = await Promise.all([
       listAdminUsers(c.env.DB),

--- a/worker/src/data/users.js
+++ b/worker/src/data/users.js
@@ -72,3 +72,19 @@ export async function listAdminUsers(db) {
 		.all();
 	return results.map(mapAdminUser);
 }
+
+export async function listStorageOwners(db) {
+	const { results } = await db
+		.prepare(
+			`SELECT id, username, display_name, deleted_at
+			 FROM users
+			 ORDER BY id ASC`,
+		)
+		.all();
+	return results.map((row) => ({
+		id: Number(row.id),
+		username: row.username,
+		displayName: row.display_name,
+		isDeleted: Boolean(row.deleted_at),
+	}));
+}

--- a/worker/src/storage-statistics.js
+++ b/worker/src/storage-statistics.js
@@ -1,0 +1,49 @@
+const USER_OBJECT_KEY_PATTERN = /^(\d+)\//;
+
+export function storageOwnerFromObjectKey(key) {
+	const normalizedKey = String(key || "");
+	const userMatch = USER_OBJECT_KEY_PATTERN.exec(normalizedKey);
+	if (userMatch) {
+		const userId = Number(userMatch[1]);
+		if (Number.isSafeInteger(userId) && userId > 0) {
+			return { key: `user:${userId}`, type: "user", userId };
+		}
+	}
+
+	if (normalizedKey.startsWith("telegram/")) {
+		return { key: "system:telegram", type: "telegram", userId: null };
+	}
+
+	return { key: "system:unknown", type: "unknown", userId: null };
+}
+
+export function summarizeR2Objects(objects = []) {
+	const summaries = new Map();
+
+	for (const object of objects) {
+		const owner = storageOwnerFromObjectKey(object?.key);
+		const current = summaries.get(owner.key) || {
+			ownerKey: owner.key,
+			ownerType: owner.type,
+			ownerId: owner.userId,
+			objectCount: 0,
+			bytes: 0,
+			latestUploadedAt: null,
+		};
+		const uploadedAt = object?.uploaded ? new Date(object.uploaded) : null;
+
+		current.objectCount += 1;
+		current.bytes += Math.max(0, Number(object?.size) || 0);
+		if (
+			uploadedAt &&
+			!Number.isNaN(uploadedAt.getTime()) &&
+			(!current.latestUploadedAt || uploadedAt > new Date(current.latestUploadedAt))
+		) {
+			current.latestUploadedAt = uploadedAt.toISOString();
+		}
+
+		summaries.set(owner.key, current);
+	}
+
+	return [...summaries.values()];
+}


### PR DESCRIPTION
## Summary

- add an admin-only R2 storage statistics page with manual refresh
- scan R2 objects page by page and aggregate actual object bytes by uploader
- include active users with zero usage and separate Telegram/unknown objects
- support ascending/descending sorting by file count, storage usage, share, and latest upload time
- keep object keys and filenames out of the admin API response

## Implementation notes

- each API request lists at most 1,000 R2 objects and returns an opaque cursor
- the browser follows cursors and merges per-owner aggregates only after the full scan succeeds
- the endpoint remains protected by the existing admin middleware and uses no-store caching
- no D1 schema migration or scheduled job is required

## Verification

- node --test --test-concurrency=1 (116 tests passed)
- npm run build
- npx wrangler deploy --dry-run --config wrangler.example.toml